### PR TITLE
Fix story branch checkout to reuse existing branches

### DIFF
--- a/AI-INSTRUCTIONS.md
+++ b/AI-INSTRUCTIONS.md
@@ -292,7 +292,7 @@ Generates branch name: `<type>/sc-<id>/<slugified-title>`.
 
 ```sh
 shortcut story branch --id 12345              # feature/sc-12345/add-user-auth
-shortcut story branch --id 12345 --checkout   # create + checkout
+shortcut story branch --id 12345 --checkout   # create if needed + checkout
 shortcut story branch --id 12345 --prefix hotfix  # hotfix/sc-12345/...
 ```
 

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -2140,7 +2140,7 @@ sc story branch --id 123 --checkout
 - Naming convention: `{type}/sc-{id}-{slugified-name}`.
   - Slugify: lowercase, replace non-alphanumeric with hyphens, collapse consecutive hyphens, truncate to 50 chars.
 - The `--prefix` flag overrides the type-based prefix.
-- The `--checkout` flag (or `-c`) creates the branch and checks it out (`git checkout -b <branch>`).
+- The `--checkout` flag (or `-c`) checks out the branch, creating it first only when it does not already exist locally.
 - Without `--checkout`, just print the suggested branch name.
 - Use `std::process::Command` to run git commands.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Run `shortcut <command> --help` for full flag documentation.
 shortcut story branch --id 12345
 # feature/sc-12345/add-user-authentication
 
-# Create and checkout the branch
+# Create the branch if needed, then checkout
 shortcut story branch --id 12345 --checkout
 
 # Override the type prefix

--- a/src/commands/story/branch.rs
+++ b/src/commands/story/branch.rs
@@ -51,8 +51,13 @@ pub async fn run_with_git(
     );
 
     if args.checkout {
-        git_runner.checkout_new_branch(&branch)?;
-        out_println!(out, "Checked out new branch: {branch}");
+        if git_runner.branch_exists(&branch)? {
+            git_runner.checkout_branch(&branch)?;
+            out_println!(out, "Checked out existing branch: {branch}");
+        } else {
+            git_runner.checkout_new_branch(&branch)?;
+            out_println!(out, "Created and checked out branch: {branch}");
+        }
     } else if out.is_machine_readable() {
         let json = serde_json::json!({ "branch": branch });
         out_println!(out, "{}", serde_json::to_string_pretty(&json)?);

--- a/src/commands/story/git.rs
+++ b/src/commands/story/git.rs
@@ -55,6 +55,8 @@ pub fn extract_story_id_from_branch(branch: &str) -> Option<i64> {
 /// Abstraction over git operations for testability.
 pub trait GitRunner {
     fn current_branch(&self) -> Result<String, Box<dyn Error>>;
+    fn branch_exists(&self, branch: &str) -> Result<bool, Box<dyn Error>>;
+    fn checkout_branch(&self, branch: &str) -> Result<(), Box<dyn Error>>;
     fn checkout_new_branch(&self, branch: &str) -> Result<(), Box<dyn Error>>;
     fn commit(&self, args: &[&str]) -> Result<String, Box<dyn Error>>;
 }
@@ -76,6 +78,42 @@ impl GitRunner for RealGitRunner {
             .into());
         }
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn branch_exists(&self, branch: &str) -> Result<bool, Box<dyn Error>> {
+        let ref_name = format!("refs/heads/{branch}");
+        let output = std::process::Command::new("git")
+            .args(["show-ref", "--verify", "--quiet", &ref_name])
+            .output()
+            .map_err(|e| format!("Failed to run git: {e}"))?;
+        if output.status.success() {
+            return Ok(true);
+        }
+
+        if output.status.code() == Some(1) {
+            return Ok(false);
+        }
+
+        Err(format!(
+            "git show-ref failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into())
+    }
+
+    fn checkout_branch(&self, branch: &str) -> Result<(), Box<dyn Error>> {
+        let output = std::process::Command::new("git")
+            .args(["checkout", branch])
+            .output()
+            .map_err(|e| format!("Failed to run git: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "git checkout failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+            .into());
+        }
+        Ok(())
     }
 
     fn checkout_new_branch(&self, branch: &str) -> Result<(), Box<dyn Error>> {

--- a/tests/story/branch.rs
+++ b/tests/story/branch.rs
@@ -11,21 +11,30 @@ use shortcut_cli::output::{ColorMode, OutputConfig, OutputMode};
 use crate::support::full_story_json;
 
 struct TestGitRunner {
+    branch_exists: bool,
     checkout_result: Result<(), String>,
+    checkout_new_branch_called: RefCell<bool>,
+    checkout_branch_called: RefCell<bool>,
     checked_out_branch: RefCell<Option<String>>,
 }
 
 impl TestGitRunner {
-    fn ok() -> Self {
+    fn new(branch_exists: bool) -> Self {
         Self {
+            branch_exists,
             checkout_result: Ok(()),
+            checkout_new_branch_called: RefCell::new(false),
+            checkout_branch_called: RefCell::new(false),
             checked_out_branch: RefCell::new(None),
         }
     }
 
-    fn failing(msg: &str) -> Self {
+    fn failing(branch_exists: bool, msg: &str) -> Self {
         Self {
+            branch_exists,
             checkout_result: Err(msg.to_string()),
+            checkout_new_branch_called: RefCell::new(false),
+            checkout_branch_called: RefCell::new(false),
             checked_out_branch: RefCell::new(None),
         }
     }
@@ -36,7 +45,20 @@ impl git::GitRunner for TestGitRunner {
         unimplemented!("not used in branch tests")
     }
 
+    fn branch_exists(&self, _branch: &str) -> Result<bool, Box<dyn Error>> {
+        Ok(self.branch_exists)
+    }
+
+    fn checkout_branch(&self, branch: &str) -> Result<(), Box<dyn Error>> {
+        *self.checkout_branch_called.borrow_mut() = true;
+        *self.checked_out_branch.borrow_mut() = Some(branch.to_string());
+        self.checkout_result
+            .clone()
+            .map_err(|e| -> Box<dyn Error> { e.into() })
+    }
+
     fn checkout_new_branch(&self, branch: &str) -> Result<(), Box<dyn Error>> {
+        *self.checkout_new_branch_called.borrow_mut() = true;
         *self.checked_out_branch.borrow_mut() = Some(branch.to_string());
         self.checkout_result
             .clone()
@@ -65,7 +87,7 @@ async fn print_branch_name() {
     setup_mock(&server, 123, "Fix Login Bug").await;
 
     let client = api::client_with_token("test-token", &server.uri()).unwrap();
-    let git_runner = TestGitRunner::ok();
+    let git_runner = TestGitRunner::new(false);
     let args = branch::BranchArgs {
         id: 123,
         prefix: None,
@@ -86,7 +108,7 @@ async fn custom_prefix() {
     setup_mock(&server, 123, "Fix Login Bug").await;
 
     let client = api::client_with_token("test-token", &server.uri()).unwrap();
-    let git_runner = TestGitRunner::ok();
+    let git_runner = TestGitRunner::new(false);
     let args = branch::BranchArgs {
         id: 123,
         prefix: Some("hotfix".to_string()),
@@ -107,7 +129,7 @@ async fn checkout_mode() {
     setup_mock(&server, 123, "Fix Login Bug").await;
 
     let client = api::client_with_token("test-token", &server.uri()).unwrap();
-    let git_runner = TestGitRunner::ok();
+    let git_runner = TestGitRunner::new(false);
     let args = branch::BranchArgs {
         id: 123,
         prefix: None,
@@ -118,11 +140,40 @@ async fn checkout_mode() {
     assert!(result.is_ok());
 
     let output = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
-    assert!(output.contains("Checked out new branch:"));
+    assert!(output.contains("Created and checked out branch:"));
     assert!(output.contains("feature/sc-123-fix-login-bug"));
 
     let checked_out = git_runner.checked_out_branch.borrow();
     assert_eq!(checked_out.as_deref(), Some("feature/sc-123-fix-login-bug"));
+    assert!(*git_runner.checkout_new_branch_called.borrow());
+    assert!(!*git_runner.checkout_branch_called.borrow());
+}
+
+#[tokio::test]
+async fn checkout_existing_branch() {
+    let (out, buf) = OutputConfig::with_buffer(OutputMode::Human, ColorMode::Never);
+    let server = MockServer::start().await;
+    setup_mock(&server, 123, "Fix Login Bug").await;
+
+    let client = api::client_with_token("test-token", &server.uri()).unwrap();
+    let git_runner = TestGitRunner::new(true);
+    let args = branch::BranchArgs {
+        id: 123,
+        prefix: None,
+        checkout: true,
+    };
+
+    let result = branch::run_with_git(&args, &client, &out, &git_runner).await;
+    assert!(result.is_ok());
+
+    let output = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(output.contains("Checked out existing branch:"));
+    assert!(output.contains("feature/sc-123-fix-login-bug"));
+
+    let checked_out = git_runner.checked_out_branch.borrow();
+    assert_eq!(checked_out.as_deref(), Some("feature/sc-123-fix-login-bug"));
+    assert!(!*git_runner.checkout_new_branch_called.borrow());
+    assert!(*git_runner.checkout_branch_called.borrow());
 }
 
 #[tokio::test]
@@ -138,7 +189,7 @@ async fn api_failure_returns_error() {
         .await;
 
     let client = api::client_with_token("test-token", &server.uri()).unwrap();
-    let git_runner = TestGitRunner::ok();
+    let git_runner = TestGitRunner::new(false);
     let args = branch::BranchArgs {
         id: 999,
         prefix: None,
@@ -156,7 +207,7 @@ async fn git_checkout_failure_propagates() {
     setup_mock(&server, 123, "Fix Login Bug").await;
 
     let client = api::client_with_token("test-token", &server.uri()).unwrap();
-    let git_runner = TestGitRunner::failing("branch already exists");
+    let git_runner = TestGitRunner::failing(false, "branch already exists");
     let args = branch::BranchArgs {
         id: 123,
         prefix: None,

--- a/tests/story/commit.rs
+++ b/tests/story/commit.rs
@@ -25,6 +25,14 @@ impl git::GitRunner for TestGitRunner {
         Ok(self.branch.clone())
     }
 
+    fn branch_exists(&self, _branch: &str) -> Result<bool, Box<dyn Error>> {
+        unimplemented!("not used in commit tests")
+    }
+
+    fn checkout_branch(&self, _branch: &str) -> Result<(), Box<dyn Error>> {
+        unimplemented!("not used in commit tests")
+    }
+
     fn checkout_new_branch(&self, _branch: &str) -> Result<(), Box<dyn Error>> {
         unimplemented!("not used in commit tests")
     }


### PR DESCRIPTION
## Summary
- Make `shortcut story branch --checkout` reuse an existing local branch instead of always creating a new one
- Keep branch creation behavior when the target branch does not exist locally
- Update checkout messaging and docs to match the new behavior

## Testing
- `cargo test --test story -- --nocapture`
- `cargo test git:: --lib -- --nocapture`
- `cargo fmt -- --check`